### PR TITLE
Fix:リンク名変更

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,18 +5,18 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" /></svg>
       </label>
       <ul tabindex="0" class="menu menu-sm text-gray-700 dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
-        <li><%= link_to "目標・タスク一覧", goals_path %></li>
-        <li><%= link_to "達成一覧", look_back_path %></li>
-        <li><%= link_to "開花一覧", flowers_path %><li>
+        <li><%= link_to t("defaults.link_goal"), goals_path %></li>
+        <li><%= link_to t("defaults.link_look_back"), look_back_path %></li>
+        <li><%= link_to t("defaults.link_flower"), flowers_path %></li>
       </ul>
     </div>
     <%= link_to 'GrowJourney', goals_path, class: "text-lg font-bold" %>
   </div>
   <div class="navbar-center hidden lg:flex">
     <ul class="menu menu-horizontal px-1">
-        <li><%= link_to "目標・タスク一覧", goals_path, class:"font-bold"%></li>
-        <li><%= link_to "達成一覧", look_back_path, class:"font-bold" %></li>
-        <li><%= link_to "開花一覧", flowers_path, class:"font-bold" %><li>
+        <li><%= link_to t("defaults.link_goal"), goals_path, class:"font-bold"%></li>
+        <li><%= link_to t("defaults.link_look_back"), look_back_path, class:"font-bold" %></li>
+        <li><%= link_to t("defaults.link_flower"), flowers_path, class:"font-bold" %></li>
     </ul>
   </div>
   <div class="navbar-end">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,9 @@ ja:
     to_login_page: 'ログインページへ'
     cancel: キャンセル
     submit: 保存
+    link_goal: "目標・タスク一覧"
+    link_look_back: 振り返り
+    link_flower: 開花一覧
     message:
       login: 'ログインしました'
       require_login: 'ログインしてください'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ヘッダー内のリンクテキストを多言語対応に更新しました。
		- 「目標・タスク一覧」を「目標」に変更。
		- 「達成一覧」を「振り返り」に変更。
		- 「開花一覧」を「開花」に変更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->