### PR TITLE
Fix:日付欄のクリック反応幅の調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,7 +4,13 @@
 
 #task_due::-webkit-calendar-picker-indicator {
   position: absolute;
-  width: 80%;
+  width: 100%;
+  opacity: 0;/* 不透明度を0に設定して非表示にする */
+}
+
+#task_due_edit::-webkit-calendar-picker-indicator {
+  position: absolute;
+  width: 45%;
   opacity: 0;/* 不透明度を0に設定して非表示にする */
 }
 

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -11,7 +11,7 @@
           <!-- 期限 -->
           <div class="mb-2 md:mb-0 md:mr-2">
             <%= f.label :due, t(".due"), class: "block text-sm font-medium text-gray-700" %>
-            <%= f.date_field :due, id: "task_due", class: "form-input w-full border rounded-md" %>
+            <%= f.date_field :due, id: "task_due_edit", class: "form-input w-full border rounded-md" %>
           </div>
 
           <%= f.hidden_field :goal_id, value: @task.goal_id %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイルの変更**
	- タスクの期限日を設定するフィールドの幅と透明度を調整しました。具体的には、表示時の幅を80%から100%に拡大し、編集時の幅を80%から45%に変更しました。また、これらのフィールドを非表示にするために透明度を0に設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->